### PR TITLE
separer callback_uri ut fra reg link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       CheckFiles: "launcher.py cogs/"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.3
         with:
           ref: ${{ github.head_ref }}
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.3
       - name: Create VARS
         env:
           _repo: ${{github.repository}}

--- a/cogs/github.py
+++ b/cogs/github.py
@@ -54,10 +54,11 @@ class Github(commands.Cog):
         try:
             embed = easy_embed(self, ctx)
             discord_id_and_key = f"{ctx.author.id}:{random_string}"
+            callback = f"{self.bot.settings.github['callback_uri']}" \
+                       f"?params={discord_id_and_key}"
             registration_link = "https://github.com/login/oauth/authorize" \
                                 f"?client_id={self.bot.settings.github['client_id']}" \
-                                f"&redirect_uri={self.bot.settings.github['callback_uri']}" \
-                                f"?params={discord_id_and_key}"
+                                f"&redirect_uri={callback}"
             embed.title = "Hei! For å verifisere GitHub kontoen din, følg lenken under"
             embed.description = f"[Verifiser med GitHub]({registration_link})"
             await ctx.author.send(embed=embed)


### PR DESCRIPTION
separerer oppbygging av `callback_uri` slik at denne blir bygget opp utenfor `registration_link`

https://github.com/Roxedus/ProgBott/blob/master/cogs/github.py#L57-L60

På linje 60 så kommer det ikke tydelig fram at `?params` må sees i kontekst av linjen før og  `callback_uri` - at denne linjen er en del av oppbyggingen av `callback_uri`

Koden er ikke testet, og jeg ser nå at variabelen kunne vært `callback_uri` istedenfor `callback`